### PR TITLE
Add optional Python package index URL to the package request

### DIFF
--- a/.github/ISSUE_TEMPLATE/package_request.yaml
+++ b/.github/ISSUE_TEMPLATE/package_request.yaml
@@ -21,6 +21,15 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: index_url
+    attributes:
+      label: Python package index URL
+      description: Python package index where the given package is hosted
+      placeholder: https://pypi.org/simple
+    validations:
+      required: false
+
   - type: textarea
     id: reason
     attributes:


### PR DESCRIPTION
Let's have also this field as per discussion with @pacospace. It might be helpful in some cases.